### PR TITLE
Add helpers for creating queues from shared memory via raw pointers + add multi-thread test

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -159,14 +159,14 @@ impl<'a> YCQueue <'a> {
         }
     }
 
-    pub fn mark_slot_produced(&mut self, queue_slot: YCQueueProduceSlot<'a>) -> Option<YCQueueError> {
+    pub fn mark_slot_produced(&mut self, queue_slot: YCQueueProduceSlot<'a>) -> Result<(), YCQueueError> {
         /*
          * Marking a slot as produced gives it to the consumer to consume. These are not required 
          * to happen in the same order the slots were reserved. This updates the in-flight count.
          */
         
         if queue_slot.data.len() != self.slot_size as usize {
-            return Some(YCQueueError::InvalidArgs);
+            return Err(YCQueueError::InvalidArgs);
         }
 
         // yoink back the slot data
@@ -200,7 +200,7 @@ impl<'a> YCQueue <'a> {
             break;
         }
 
-        None
+        Ok(())
     }
 
     pub fn get_consume_slot(&mut self) -> Result<YCQueueConsumeSlot<'a>, YCQueueError> {
@@ -241,9 +241,9 @@ impl<'a> YCQueue <'a> {
         }
     }
 
-    pub fn mark_slot_consumed(&mut self, queue_slot: YCQueueConsumeSlot<'a>) -> Option<YCQueueError> {
+    pub fn mark_slot_consumed(&mut self, queue_slot: YCQueueConsumeSlot<'a>) -> Result<(), YCQueueError> {
         if queue_slot.data.len() != self.slot_size as usize {
-            return Some(YCQueueError::InvalidArgs);
+            return Err(YCQueueError::InvalidArgs);
         }
 
         // yoink back the slot data
@@ -256,7 +256,7 @@ impl<'a> YCQueue <'a> {
         let old_owner = self.set_owner(consume_idx, YCQueueOwner::Producer);
         assert_eq!(old_owner, YCQueueOwner::Consumer);
 
-        None
+        Ok(())
     }
 
 }

--- a/src/queue_alloc_helpers.rs
+++ b/src/queue_alloc_helpers.rs
@@ -1,5 +1,7 @@
 use std::sync::atomic::{AtomicU16, AtomicU64};
 
+use crate::{YCQueueError, YCQueueSharedMeta};
+
 pub struct YCQueueOwnedMeta {
     pub slot_count: AtomicU16,
     pub slot_size: AtomicU16,
@@ -22,17 +24,61 @@ impl YCQueueOwnedMeta {
     }
 }
 
-/// A way to hold a YCQueueSharedMeta to share between threads of a particular rust program. Not designed for IPC. 
-pub struct YCQueueData {
-    pub meta: YCQueueOwnedMeta,
-    pub data: Vec<u8>,
+impl<'a> YCQueueSharedMeta<'a> {
+    pub fn new(meta_ref: &YCQueueOwnedMeta) -> YCQueueSharedMeta {
+        YCQueueSharedMeta {slot_count: &meta_ref.slot_count, slot_size: &meta_ref.slot_size, u64_meta: &meta_ref.produce_meta, ownership: &meta_ref.ownership}
+    }
+    
+    pub fn new_from_mut_ptr(ptr: *mut u8) -> Result<YCQueueSharedMeta<'a>, YCQueueError> {
+        if ptr.is_null() {
+            return Err(YCQueueError::InvalidArgs);
+        }
+
+        let slot_count_ptr = ptr as *mut AtomicU16;
+        let slot_size_ptr = unsafe { slot_count_ptr.add(1) };
+        let u64_meta_ptr = unsafe { slot_size_ptr.add(1) as *mut AtomicU64 };
+
+        let slot_count = unsafe { &*slot_count_ptr };
+        let slot_size = unsafe { &*slot_size_ptr };
+        let produce_meta = unsafe { &*u64_meta_ptr };
+
+        let slot_count_u16 = slot_count.load(std::sync::atomic::Ordering::Acquire);
+        let ownership_count = (slot_count_u16 as usize + u64::BITS as usize - 1) / u64::BITS as usize;
+        let ownership_ptr = unsafe { u64_meta_ptr.add(1) as *mut AtomicU64 };
+
+        let ownership_slice = unsafe { std::slice::from_raw_parts_mut(ownership_ptr, ownership_count) };
+
+        Ok(YCQueueSharedMeta {slot_count, slot_size, u64_meta: produce_meta, ownership: ownership_slice})
+    }
 }
 
-impl YCQueueData {
-    pub fn new(slot_count_u16: u16, slot_size_u16: u16) -> YCQueueData {
-        let meta = YCQueueOwnedMeta::new(slot_count_u16, slot_size_u16);
-        let data = vec![0 as u8; (slot_count_u16 * slot_size_u16) as usize];
+/// A way to hold a YCQueueSharedMeta to share between threads of a particular rust program. Not designed for IPC. 
+pub struct YCQueueOwnedData {
+    pub meta: YCQueueOwnedMeta,
+    pub data: Vec<u8>,
+    pub raw_ptr: *mut u8,
+}
 
-        YCQueueData {meta, data}
+impl YCQueueOwnedData {
+    pub fn new(slot_count_u16: u16, slot_size_u16: u16) -> YCQueueOwnedData {
+        let meta = YCQueueOwnedMeta::new(slot_count_u16, slot_size_u16);
+        let mut data = vec![0 as u8; (slot_count_u16 * slot_size_u16) as usize];
+        let raw_ptr = data.as_mut_ptr();
+
+        YCQueueOwnedData {meta, data, raw_ptr}
+    }
+}
+
+pub struct YCQueueSharedData<'a> {
+    pub meta: YCQueueSharedMeta<'a>,
+    pub data: &'a mut [u8],
+}
+
+impl<'a> YCQueueSharedData<'a> {
+    pub fn from_owned_data(owned: &'a YCQueueOwnedData) -> YCQueueSharedData<'a> {
+        let meta = YCQueueSharedMeta::new(&owned.meta);
+        let data = owned.raw_ptr;
+
+        YCQueueSharedData {meta, data: unsafe { std::slice::from_raw_parts_mut(data, owned.data.len()) }}
     }
 }

--- a/src/queue_meta.rs
+++ b/src/queue_meta.rs
@@ -1,8 +1,5 @@
 use std::sync::atomic::{AtomicU16, AtomicU64};
 
-use crate::queue_alloc_helpers::YCQueueOwnedMeta;
-
-
 /// shared data associated with the metadata portion of the circular queue. All of these types are references, 
 /// as they should point to some shared memory region. 
 pub struct YCQueueSharedMeta<'a> {
@@ -14,12 +11,6 @@ pub struct YCQueueSharedMeta<'a> {
     // TODO: implement EXPAND
     // "busy bit" to implement locking for segment growth
     // busy: &'a AtomicBool,
-}
-
-impl<'a> YCQueueSharedMeta<'a> {
-    pub fn new(meta_ref: &YCQueueOwnedMeta) -> YCQueueSharedMeta {
-        YCQueueSharedMeta {slot_count: &meta_ref.slot_count, slot_size: &meta_ref.slot_size, u64_meta: &meta_ref.produce_meta, ownership: &meta_ref.ownership}
-    }
 }
 
 pub(crate) struct YCQueueU64Meta {

--- a/tests/multi_thread_tests.rs
+++ b/tests/multi_thread_tests.rs
@@ -1,0 +1,101 @@
+#[cfg(test)]
+mod tests {
+    use yep_coc::queue_alloc_helpers::{YCQueueOwnedData, YCQueueSharedData};
+    use yep_coc::{YCQueue, YCQueueError};
+
+    pub fn str_to_u8(s: &str) -> &[u8] {
+        return s.as_bytes();
+    }
+
+    pub fn str_from_u8(buf: &[u8]) -> &str {
+        let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+        match std::str::from_utf8(&buf[..len]) {
+            Ok(s) => s,
+            Err(e) => panic!(
+                "couldn't parse as utf-8 string, err: {:?} buf: {:?}",
+                e, buf
+            ),
+        }
+    }
+
+    pub fn copy_str_to_slice(s: &str, buf: &mut [u8]) {
+        let s_bytes = str_to_u8(s);
+        assert!(s_bytes.len() <= buf.len(), "dst buffer not large enough!");
+
+        buf[..s_bytes.len()].copy_from_slice(s_bytes);
+    }
+
+    #[test]
+    /**
+     * Simple test that produces and consumes two items from the queue with the pattern
+     * produce -> consume -> produce -> consume, checking queue state and data contents along the way.
+     */
+    fn simple_produce_consume_test() {
+        let slot_count: u16 = 64;
+        let slot_size: u16 = 64;
+        let num_iterations: u16 = 10;
+
+        // this is the "original" data - it owned the underlying allocations
+        let owned_data = YCQueueOwnedData::new(slot_count, slot_size);
+
+        // we have to make a shared version to use in the other thread
+        let consume_data = YCQueueSharedData::from_owned_data(&owned_data);
+        let produce_data = YCQueueSharedData::from_owned_data(&owned_data);
+
+        // set up consumed thread to poll & consume data
+        let mut consume_queue = YCQueue::new(consume_data.meta, consume_data.data).unwrap();
+        let mut produce_queue = YCQueue::new(produce_data.meta, produce_data.data).unwrap();
+
+        std::thread::scope(|s| {
+            // consumer thread
+            s.spawn(move || {
+                let mut counter = 0;
+
+                while counter < slot_count * num_iterations {
+                    match consume_queue.get_consume_slot() {
+                        Ok(consume_slot) => {
+                            let expected_str = format!("hello-{}", counter);
+                            let actual_str = str_from_u8(consume_slot.data);
+                            assert_eq!(
+                                expected_str, actual_str,
+                                "consumed data does not match expected"
+                            );
+                            consume_queue.mark_slot_consumed(consume_slot).unwrap();
+                            counter += 1;
+                        }
+                        Err(YCQueueError::EmptyQueue) | Err(YCQueueError::SlotNotReady) => {
+                            // no data yet, just spin
+                            std::thread::yield_now();
+                        }
+                        Err(e) => {
+                            panic!("unexpected error when consuming: {:?}", e);
+                        }
+                    }
+                }
+            });
+
+            // producer thread
+            s.spawn(move || {
+                let mut counter = 0;
+
+                while counter < slot_count * num_iterations {
+                    match produce_queue.get_produce_slot() {
+                        Ok(mut produce_slot) => {
+                            let produce_str = format!("hello-{}", counter);
+                            copy_str_to_slice(&produce_str, &mut produce_slot.data);
+                            produce_queue.mark_slot_produced(produce_slot).unwrap();
+                            counter += 1;
+                        }
+                        Err(YCQueueError::OutOfSpace) | Err(YCQueueError::SlotNotReady) => {
+                            // queue is full, just spin
+                            std::thread::yield_now();
+                        }
+                        Err(e) => {
+                            panic!("unexpected error when producing: {:?}", e);
+                        }
+                    }
+                }
+            });
+        });
+    }
+}

--- a/tests/single_thread_tests.rs
+++ b/tests/single_thread_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use yep_coc::{YCQueue, YCQueueError, YCQueueProduceSlot, YCQueueSharedMeta};
-    use yep_coc::queue_alloc_helpers::YCQueueData;
+    use yep_coc::queue_alloc_helpers::YCQueueOwnedData;
     
 
     pub fn str_to_u8(s: &str) -> &[u8] {
@@ -35,7 +35,7 @@ mod tests {
         /*
          * Set up the "shared metadata" for the queue
          */
-        let mut owned_data = YCQueueData::new(slot_count, slot_size);
+        let mut owned_data = YCQueueOwnedData::new(slot_count, slot_size);
         let shared_meta = YCQueueSharedMeta::new(&owned_data.meta);
 
         // set up the queue
@@ -73,7 +73,7 @@ mod tests {
         assert_eq!(queue.consume_idx(), 0);
 
         // produce into the first queue slot
-        queue.mark_slot_produced(queue_slot_0);
+        queue.mark_slot_produced(queue_slot_0).unwrap();
         assert_eq!(queue.in_flight_count(), 1);
         assert_eq!(queue.produce_idx(), 2);
         
@@ -97,7 +97,7 @@ mod tests {
 
         // produce second data item
         // produce into the first queue slot
-        queue.mark_slot_produced(queue_slot_1);
+        queue.mark_slot_produced(queue_slot_1).unwrap();
         assert_eq!(queue.in_flight_count(), 1);
         assert_eq!(queue.produce_idx(), 2);
 
@@ -113,8 +113,8 @@ mod tests {
         assert_eq!(str_from_u8(consume_slot_1.data), second_test_msg);
 
         // mark slots as consumed
-        queue.mark_slot_consumed(consume_slot_0);
-        queue.mark_slot_consumed(consume_slot_1);
+        queue.mark_slot_consumed(consume_slot_0).unwrap();
+        queue.mark_slot_consumed(consume_slot_1).unwrap();
 
         // check fields
         assert_eq!(queue.in_flight_count(), 0);
@@ -131,7 +131,7 @@ mod tests {
         /*
          * Set up the "shared metadata" for the queue
          */
-        let mut owned_data = YCQueueData::new(slot_count, slot_size);
+        let mut owned_data = YCQueueOwnedData::new(slot_count, slot_size);
         let shared_meta = YCQueueSharedMeta::new(&owned_data.meta);
 
         // set up the queue
@@ -156,7 +156,7 @@ mod tests {
 
         // produce entire queue
         for slot in slots.into_iter() {
-            queue.mark_slot_produced(slot);
+            queue.mark_slot_produced(slot).unwrap();
         }
 
         // check queue stats
@@ -171,7 +171,7 @@ mod tests {
         assert_eq!(consume_slot.index, 0);
         assert_eq!(queue.consume_idx(), 1);
 
-        queue.mark_slot_consumed(consume_slot);
+        queue.mark_slot_consumed(consume_slot).unwrap();
         assert_eq!(queue.consume_idx(), 1);
 
         // make sure we can produce exactly one more element
@@ -181,13 +181,13 @@ mod tests {
         assert_eq!(queue.consume_idx(), 1);
 
         assert_eq!(queue.get_produce_slot().unwrap_err(), YCQueueError::OutOfSpace);
-        
-        assert_eq!(queue.mark_slot_produced(produce_slot), None);
+
+        queue.mark_slot_produced(produce_slot).unwrap();
 
         // consume the entire queue
         for _ in 0..slot_count {
             let consume_slot = queue.get_consume_slot().unwrap();
-            queue.mark_slot_consumed(consume_slot);
+            queue.mark_slot_consumed(consume_slot).unwrap();
         }
 
     }
@@ -200,7 +200,7 @@ mod tests {
         /*
          * Set up the "shared metadata" for the queue
          */
-        let mut owned_data = YCQueueData::new(slot_count, slot_size);
+        let mut owned_data = YCQueueOwnedData::new(slot_count, slot_size);
         let shared_meta = YCQueueSharedMeta::new(&owned_data.meta);
 
         // set up the queue
@@ -214,13 +214,13 @@ mod tests {
         assert_eq!(queue_slot_1.index, 1);
 
         // produce "second" queue slot first
-        assert_eq!(queue.mark_slot_produced(queue_slot_1), None);
+        queue.mark_slot_produced(queue_slot_1).unwrap();
 
         // consume should fail
         assert_eq!(queue.get_consume_slot().unwrap_err(), YCQueueError::SlotNotReady);
 
         // until we produce the first slsot
-        assert_eq!(queue.mark_slot_produced(queue_slot_0), None);
+        queue.mark_slot_produced(queue_slot_0).unwrap();
 
         assert_eq!(queue.get_consume_slot().unwrap().index, 0);
         assert_eq!(queue.get_consume_slot().unwrap().index, 1);
@@ -234,7 +234,7 @@ mod tests {
         /*
          * Set up the "shared metadata" for the queue
          */
-        let mut owned_data = YCQueueData::new(slot_count, slot_size);
+        let mut owned_data = YCQueueOwnedData::new(slot_count, slot_size);
         let shared_meta = YCQueueSharedMeta::new(&owned_data.meta);
 
         // set up the queue
@@ -243,7 +243,7 @@ mod tests {
         // produce entire queue
         for _ in 0..slot_count {
             let queue_slot = queue.get_produce_slot().unwrap();
-            assert_eq!(queue.mark_slot_produced(queue_slot), None);
+            queue.mark_slot_produced(queue_slot).unwrap();
         }
         assert_eq!(queue.produce_idx(), 0);
         assert_eq!(queue.consume_idx(), 0);
@@ -257,13 +257,13 @@ mod tests {
         assert_eq!(consume_slot_1.index, 1);
 
         // mark second slot consumed
-        assert_eq!(queue.mark_slot_consumed(consume_slot_1), None);
+        queue.mark_slot_consumed(consume_slot_1).unwrap();
 
         // still can't get produce slot
         assert_eq!(queue.get_produce_slot().unwrap_err(), YCQueueError::SlotNotReady);
 
         // until we mark first slot consusmed
-        assert_eq!(queue.mark_slot_consumed(consume_slot_0), None);
+        queue.mark_slot_consumed(consume_slot_0).unwrap();
 
         // then both slots can be gotten again
         assert_eq!(queue.get_produce_slot().unwrap().index, 0);
@@ -277,7 +277,7 @@ mod tests {
         const ITERATIONS: usize = 4; // Number of times to loop around the queue
 
         // Set up the queue
-        let mut owned_data = YCQueueData::new(slot_count, slot_size);
+        let mut owned_data = YCQueueOwnedData::new(slot_count, slot_size);
         let shared_meta = YCQueueSharedMeta::new(&owned_data.meta);
         let mut queue = YCQueue::new(shared_meta, owned_data.data.as_mut_slice()).unwrap();
 
@@ -298,7 +298,7 @@ mod tests {
             // Mark all slots in this batch as produced
             for _ in 0..slot_count {
                 let slot = produce_slots.remove(0);
-                queue.mark_slot_produced(slot);
+                queue.mark_slot_produced(slot).unwrap();
             }
 
             // Consume all messages in this batch
@@ -307,7 +307,7 @@ mod tests {
                 let slot = queue.get_consume_slot().unwrap();
                 let msg = str_from_u8(slot.data).to_string();
                 consumed_messages.push(msg);
-                queue.mark_slot_consumed(slot);
+                queue.mark_slot_consumed(slot).unwrap();
             }
 
             // Sort both lists since order doesn't matter within a batch


### PR DESCRIPTION
Three main things:
* changed Some(err) -> Result<(), Err>, this is better according to rust idioms
* provide helpers for creating queues from raw pointers. This is required (and unsafe) in order to share memory between threads, which is required for shared memory IPC. Only the actual memory pointer duplication requires unsafe, the rest of the code is safe rust. 
* Add test for parallel produce + consume in separate threads. 
* minor: add test in regular single thread test case to loop around the queue multiple times. 