### PR TITLE
Add new batched produce consume APIs

### DIFF
--- a/examples/multi-send-recv.rs
+++ b/examples/multi-send-recv.rs
@@ -134,26 +134,27 @@ fn main() {
     }
 
     let consumed_count = Arc::new(AtomicU32::new(0));
-    let validation_storage = Arc::new(Mutex::new(Vec::with_capacity(
-        if args.msg_check_len > 0 {
-            args.msg_count as usize
-        } else {
-            0
-        },
-    )));
+    let validation_storage = Arc::new(Mutex::new(Vec::with_capacity(if args.msg_check_len > 0 {
+        args.msg_count as usize
+    } else {
+        0
+    })));
     let producer_thread_count = args.producer_threads as u32;
     let base_messages_per_thread = args.msg_count / producer_thread_count;
     let extra_messages = args.msg_count % producer_thread_count;
 
-    let earliest_producer_start =
-        Arc::new(Mutex::new(None::<std::time::Instant>));
+    let earliest_producer_start = Arc::new(Mutex::new(None::<std::time::Instant>));
     let latest_consumer_end = Arc::new(Mutex::new(None::<std::time::Instant>));
 
     thread::scope(|s| {
         let mut next_index = 0u32;
 
         for (thread_idx, mut queue) in producer_queues.into_iter().enumerate() {
-            let extra = if thread_idx < extra_messages as usize { 1u32 } else { 0u32 };
+            let extra = if thread_idx < extra_messages as usize {
+                1u32
+            } else {
+                0u32
+            };
             let range_start = next_index;
             let range_end = range_start + base_messages_per_thread + extra;
             next_index = range_end;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -59,6 +59,53 @@ impl<'a> YCQueue<'a> {
         })
     }
 
+    fn check_owner(&self, idx: u16, range: u16, owner: YCQueueOwner) -> bool {
+        if range == 0 {
+            return true;
+        }
+        if idx >= self.slot_count || range > self.slot_count {
+            return false;
+        }
+        let mut remaining = range as u32;
+        let mut current = idx as u32;
+        let slot_count = self.slot_count as u32;
+
+        while remaining > 0 {
+            // wrap around if needed
+            if current >= slot_count {
+                // TODO: tag as cold path
+                current -= slot_count;
+            }
+            let chunk_idx = (current / u64::BITS) as usize;
+            let bit_offset = (current % u64::BITS) as u8;
+            let bits_available = u64::BITS - bit_offset as u32;
+            let span = remaining.min(bits_available);
+            debug_assert!(span > 0);
+
+            let mask = if span == u64::BITS {
+                !0u64
+            } else {
+                ((1u64 << span) - 1) << bit_offset
+            };
+            let value = self.shared_metadata.ownership[chunk_idx].load(Ordering::Acquire);
+            match owner {
+                YCQueueOwner::Producer => {
+                    if (value & mask) != 0 {
+                        return false;
+                    }
+                }
+                YCQueueOwner::Consumer => {
+                    if (value & mask) != mask {
+                        return false;
+                    }
+                }
+            }
+            remaining -= span;
+            current += span;
+        }
+        true
+    }
+
     fn get_owner(&self, idx: u16) -> YCQueueOwner {
         let atomic_idx = idx / u64::BITS as u16;
         let bit_idx = (idx % u64::BITS as u16) as u8;
@@ -96,6 +143,74 @@ impl<'a> YCQueue<'a> {
         }
     }
 
+    fn set_owner_range(
+        &mut self,
+        idx: u16,
+        range: u16,
+        owner: YCQueueOwner,
+    ) -> Result<(), YCQueueError> {
+        if range == 0 {
+            return Ok(());
+        }
+        if idx >= self.slot_count || range > self.slot_count {
+            return Err(YCQueueError::InvalidArgs);
+        }
+        let mut remaining = range as u32;
+        let mut current = idx as u32;
+        let slot_count = self.slot_count as u32;
+
+        while remaining > 0 {
+            // wrap around if needed
+            if current >= slot_count {
+                // TODO: tag as cold path
+                current -= slot_count;
+            }
+
+            let chunk_idx = (current / u64::BITS) as usize;
+            let bit_offset = (current % u64::BITS) as u8;
+            let bits_available = u64::BITS - bit_offset as u32;
+            let slots_until_end = slot_count - current;
+            let span = remaining.min(bits_available).min(slots_until_end);
+            debug_assert!(span > 0);
+
+            let mask = if span == u64::BITS {
+                !0u64
+            } else {
+                ((1u64 << span) - 1) << bit_offset
+            };
+
+            loop {
+                let value = self.shared_metadata.ownership[chunk_idx].load(Ordering::Acquire);
+
+                let new_value = match owner {
+                    YCQueueOwner::Producer => {
+                        debug_assert_eq!(value & mask, mask);
+                        value & !mask
+                    }
+                    YCQueueOwner::Consumer => {
+                        debug_assert_eq!(value & mask, 0);
+                        value | mask
+                    }
+                };
+
+                match self.shared_metadata.ownership[chunk_idx].compare_exchange(
+                    value,
+                    new_value,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => break,
+                    Err(_) => continue,
+                }
+            }
+
+            remaining -= span;
+            current += span;
+        }
+
+        Ok(())
+    }
+
     fn get_u64_meta(&self) -> YCQueueU64Meta {
         YCQueueU64Meta::from_u64(self.shared_metadata.u64_meta.load(Ordering::Acquire))
     }
@@ -112,37 +227,36 @@ impl<'a> YCQueue<'a> {
         self.get_u64_meta().consume_idx
     }
 
-    pub fn get_produce_slot(&mut self) -> Result<YCQueueProduceSlot<'a>, YCQueueError> {
-        /*
-         * In order to get a produce slot, we need to make sure it is marked as owned by producer
-         * (consumer has finished using it). Queue slots are reserved in-order but may be marked
-         * as ready for consumption out of order.
-         */
+    pub fn get_produce_slots(
+        &mut self,
+        num_slots: u16,
+    ) -> Result<Vec<YCQueueProduceSlot<'a>>, YCQueueError> {
+        if num_slots == 0 || num_slots > self.slot_count {
+            return Err(YCQueueError::InvalidArgs);
+        }
 
-        // find out what produce idx we should be using
-        let produce_idx: u16;
-        loop {
+        let start_index = loop {
             let value = self.shared_metadata.u64_meta.load(Ordering::Acquire);
             let mut meta = YCQueueU64Meta::from_u64(value);
 
-            // quick check for full queue
-            if meta.produce_idx == meta.consume_idx
-                && (meta.in_flight > 0 || meta.produce_pending > 0)
-            {
+            if meta.in_flight as u32 + num_slots as u32 > self.slot_count as u32 {
                 return Err(YCQueueError::OutOfSpace);
             }
 
-            // if the consumer still owns the current produce idx, this means the queue is full as well
-            if self.get_owner(meta.produce_idx) != YCQueueOwner::Producer {
+            // make sure all the slots we want are owned by the producer
+            if !self.check_owner(meta.produce_idx, num_slots, YCQueueOwner::Producer) {
                 return Err(YCQueueError::SlotNotReady);
             }
 
-            let temp_produce_idx: u16 = meta.produce_idx;
+            let produce_idx = meta.produce_idx;
+            meta.in_flight += num_slots;
+            meta.produce_idx += num_slots;
+            // wrap around if needed
+            if meta.produce_idx >= self.slot_count {
+                // TODO: tag as cold path
+                meta.produce_idx -= self.slot_count;
+            }
 
-            meta.produce_idx = (meta.produce_idx + 1) % self.slot_count;
-            meta.produce_pending += 1;
-
-            // update shared memory with new produce_idx
             let new_value = meta.to_u64();
             match self.shared_metadata.u64_meta.compare_exchange(
                 value,
@@ -150,27 +264,39 @@ impl<'a> YCQueue<'a> {
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
-                Ok(_) => (),
+                Ok(_) => break produce_idx,
                 Err(_) => continue,
             }
+        };
 
-            produce_idx = temp_produce_idx;
-            break;
-        }
+        let mut slots = Vec::with_capacity(num_slots as usize);
+        let mut index = start_index;
+        for _ in 0..num_slots {
+            debug_assert_eq!(self.get_owner(index), YCQueueOwner::Producer);
 
-        debug_assert_eq!(self.get_owner(produce_idx), YCQueueOwner::Producer);
-
-        // hand out the slice that corresponds to this slot
-        let slot_data = self.slots[produce_idx as usize].replace(None);
-        match slot_data {
-            Some(data) => {
-                Ok(YCQueueProduceSlot {
-                    index: produce_idx,
-                    data,
-                })
+            let slot_data = self.slots[index as usize].replace(None);
+            match slot_data {
+                Some(data) => slots.push(YCQueueProduceSlot { index, data }),
+                None => panic!("We double-loaned out produce index {:?}", index),
             }
-            None => panic!("We double-loaned out produce index {:?}", produce_idx),
+
+            index += 1;
+            // wrap around if needed
+            if index >= self.slot_count {
+                // TODO: tag as cold path
+                index -= self.slot_count;
+            }
         }
+
+        Ok(slots)
+    }
+
+    pub fn get_produce_slot(&mut self) -> Result<YCQueueProduceSlot<'a>, YCQueueError> {
+        let mut slots = self.get_produce_slots(1)?;
+
+        Ok(slots
+            .pop()
+            .expect("get_produce_slots(1) returned without a slot"))
     }
 
     pub fn mark_slot_produced(
@@ -196,55 +322,72 @@ impl<'a> YCQueue<'a> {
         let old_owner = self.set_owner(produce_idx, YCQueueOwner::Consumer);
         debug_assert_eq!(old_owner, YCQueueOwner::Producer);
 
-        // update the in-flight count
-        loop {
-            let value = self.shared_metadata.u64_meta.load(Ordering::Acquire);
-            let mut meta = YCQueueU64Meta::from_u64(value);
-
-            meta.in_flight += 1;
-
-            assert!(meta.produce_pending >= 1);
-            meta.produce_pending -= 1;
-
-            debug_assert!(meta.in_flight <= self.slot_count);
-
-            let new_value = meta.to_u64();
-            match self.shared_metadata.u64_meta.compare_exchange(
-                value,
-                new_value,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => (),
-                Err(_) => continue,
-            }
-
-            break;
-        }
-
         Ok(())
     }
 
-    pub fn get_consume_slot(&mut self) -> Result<YCQueueConsumeSlot<'a>, YCQueueError> {
-        // find out what consume idx we should be using
-        let consume_idx: u16;
-        loop {
+    pub fn mark_slots_produced(
+        &mut self,
+        queue_slots: Vec<YCQueueProduceSlot<'a>>,
+    ) -> Result<(), YCQueueError> {
+        if queue_slots.is_empty() {
+            return Ok(());
+        }
+
+        let slot_size = self.slot_size as usize;
+        let count = queue_slots.len();
+        if count > self.slot_count as usize {
+            return Err(YCQueueError::InvalidArgs);
+        }
+
+        let start_index = queue_slots[0].index;
+        let slot_count = self.slot_count as usize;
+
+        for (offset, slot) in queue_slots.iter().enumerate() {
+            if slot.data.len() != slot_size {
+                return Err(YCQueueError::InvalidArgs);
+            }
+
+            let expected = ((start_index as usize + offset) % slot_count) as u16;
+            if slot.index != expected {
+                return Err(YCQueueError::InvalidArgs);
+            }
+        }
+
+        for slot in queue_slots.into_iter() {
+            let old_data = self.slots[slot.index as usize].replace(Some(slot.data));
+            debug_assert!(old_data.is_none());
+        }
+
+        self.set_owner_range(start_index, count as u16, YCQueueOwner::Consumer)
+    }
+
+    pub fn get_consume_slots(
+        &mut self,
+        num_slots: u16,
+    ) -> Result<Vec<YCQueueConsumeSlot<'a>>, YCQueueError> {
+        if num_slots == 0 || num_slots > self.slot_count {
+            return Err(YCQueueError::InvalidArgs);
+        }
+
+        let start_index = loop {
             let value = self.shared_metadata.u64_meta.load(Ordering::Acquire);
             let mut meta = YCQueueU64Meta::from_u64(value);
 
-            if meta.in_flight == 0 {
+            if meta.in_flight < num_slots {
                 return Err(YCQueueError::EmptyQueue);
             }
 
-            // we may be stuck on a lagging slot, even though the queue is not empty
-            if self.get_owner(meta.consume_idx) != YCQueueOwner::Consumer {
+            if !self.check_owner(meta.consume_idx, num_slots, YCQueueOwner::Consumer) {
                 return Err(YCQueueError::SlotNotReady);
             }
 
-            let temp_consume_idx: u16 = meta.consume_idx;
-
-            meta.consume_idx = (meta.consume_idx + 1) % self.slot_count;
-            meta.in_flight -= 1;
+            let consume_idx = meta.consume_idx;
+            let mut next_idx = consume_idx as u32 + num_slots as u32;
+            if next_idx >= self.slot_count as u32 {
+                next_idx -= self.slot_count as u32;
+            }
+            meta.consume_idx = next_idx as u16;
+            meta.in_flight -= num_slots;
 
             let new_value = meta.to_u64();
             match self.shared_metadata.u64_meta.compare_exchange(
@@ -253,24 +396,37 @@ impl<'a> YCQueue<'a> {
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
-                Ok(_) => (),
+                Ok(_) => break consume_idx,
                 Err(_) => continue,
             }
+        };
 
-            consume_idx = temp_consume_idx;
-            break;
-        }
+        let mut slots = Vec::with_capacity(num_slots as usize);
+        let mut index = start_index;
+        for _ in 0..num_slots {
+            debug_assert_eq!(self.get_owner(index), YCQueueOwner::Consumer);
 
-        let slot_data = self.slots[consume_idx as usize].replace(None);
-        match slot_data {
-            Some(data) => {
-                Ok(YCQueueConsumeSlot {
-                    index: consume_idx,
-                    data,
-                })
+            let slot_data = self.slots[index as usize].replace(None);
+            match slot_data {
+                Some(data) => slots.push(YCQueueConsumeSlot { index, data }),
+                None => panic!("We double-loaned out consume index {:?}", index),
             }
-            None => panic!("We double-loaned out consume index {:?}", consume_idx),
+
+            index += 1;
+            if index >= self.slot_count {
+                index -= self.slot_count;
+            }
         }
+
+        Ok(slots)
+    }
+
+    pub fn get_consume_slot(&mut self) -> Result<YCQueueConsumeSlot<'a>, YCQueueError> {
+        let mut slots = self.get_consume_slots(1)?;
+
+        Ok(slots
+            .pop()
+            .expect("get_consume_slots(1) returned without a slot"))
     }
 
     pub fn mark_slot_consumed(
@@ -292,5 +448,184 @@ impl<'a> YCQueue<'a> {
         debug_assert_eq!(old_owner, YCQueueOwner::Consumer);
 
         Ok(())
+    }
+
+    pub fn mark_slots_consumed(
+        &mut self,
+        queue_slots: Vec<YCQueueConsumeSlot<'a>>,
+    ) -> Result<(), YCQueueError> {
+        if queue_slots.is_empty() {
+            return Ok(());
+        }
+
+        let slot_size = self.slot_size as usize;
+        let count = queue_slots.len();
+        if count > self.slot_count as usize {
+            return Err(YCQueueError::InvalidArgs);
+        }
+
+        let start_index = queue_slots[0].index;
+        let slot_count = self.slot_count as usize;
+
+        for (offset, slot) in queue_slots.iter().enumerate() {
+            if slot.data.len() != slot_size {
+                return Err(YCQueueError::InvalidArgs);
+            }
+
+            let expected = ((start_index as usize + offset) % slot_count) as u16;
+            if slot.index != expected {
+                return Err(YCQueueError::InvalidArgs);
+            }
+        }
+
+        for slot in queue_slots.into_iter() {
+            let old_data = self.slots[slot.index as usize].replace(Some(slot.data));
+            debug_assert!(old_data.is_none());
+        }
+
+        self.set_owner_range(start_index, count as u16, YCQueueOwner::Producer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::YCQueueSharedMeta;
+    use crate::queue_alloc_helpers::YCQueueOwnedData;
+
+    #[test]
+    fn simple_produce_consume_test() {
+        let slot_count: u16 = 4;
+        let slot_size: u16 = 32;
+
+        let mut owned = YCQueueOwnedData::new(slot_count, slot_size);
+        let shared_meta = YCQueueSharedMeta::new(&owned.meta);
+        let mut queue = YCQueue::new(shared_meta, owned.data.as_mut_slice()).unwrap();
+
+        assert!(queue.check_owner(0, slot_count, YCQueueOwner::Producer));
+        assert_eq!(queue.in_flight_count(), 0);
+        assert_eq!(queue.produce_idx(), 0);
+        assert_eq!(queue.consume_idx(), 0);
+
+        let slot = queue.get_produce_slot().unwrap();
+        assert_eq!(slot.index, 0);
+        assert_eq!(queue.produce_idx(), 1);
+        assert_eq!(queue.in_flight_count(), 1);
+        assert!(queue.check_owner(0, 1, YCQueueOwner::Producer));
+
+        slot.data.fill(0xAB);
+        queue.mark_slot_produced(slot).unwrap();
+        assert_eq!(queue.in_flight_count(), 1);
+        assert!(queue.check_owner(0, 1, YCQueueOwner::Consumer));
+
+        let consume_slot = queue.get_consume_slot().unwrap();
+        assert_eq!(consume_slot.index, 0);
+        assert_eq!(queue.consume_idx(), 1);
+        assert_eq!(queue.in_flight_count(), 0);
+        assert!(queue.check_owner(0, 1, YCQueueOwner::Consumer));
+
+        queue.mark_slot_consumed(consume_slot).unwrap();
+        assert!(queue.check_owner(0, slot_count, YCQueueOwner::Producer));
+        assert_eq!(queue.in_flight_count(), 0);
+        assert_eq!(queue.produce_idx(), 1);
+        assert_eq!(queue.consume_idx(), 1);
+    }
+
+    #[test]
+    fn batched_produce_consume_test() {
+        let slot_count: u16 = 8;
+        let slot_size: u16 = 64;
+
+        let mut owned = YCQueueOwnedData::new(slot_count, slot_size);
+        let shared_meta = YCQueueSharedMeta::new(&owned.meta);
+        let mut queue = YCQueue::new(shared_meta, owned.data.as_mut_slice()).unwrap();
+
+        assert!(queue.check_owner(0, slot_count, YCQueueOwner::Producer));
+        assert_eq!(queue.in_flight_count(), 0);
+        assert_eq!(queue.produce_idx(), 0);
+        assert_eq!(queue.consume_idx(), 0);
+
+        let produce_batch = 3;
+        let produce_slots = queue.get_produce_slots(produce_batch).unwrap();
+        let produced_indices: Vec<_> = produce_slots.iter().map(|slot| slot.index).collect();
+        assert_eq!(produced_indices, vec![0, 1, 2]);
+        assert_eq!(queue.in_flight_count(), produce_batch);
+        assert_eq!(queue.produce_idx(), produce_batch);
+        assert!(queue.check_owner(0, produce_batch, YCQueueOwner::Producer));
+
+        queue.mark_slots_produced(produce_slots).unwrap();
+        assert!(queue.check_owner(0, produce_batch, YCQueueOwner::Consumer));
+        assert_eq!(queue.in_flight_count(), produce_batch);
+
+        let consume_slots_first = queue.get_consume_slots(2).unwrap();
+        let consumed_indices: Vec<_> = consume_slots_first.iter().map(|slot| slot.index).collect();
+        assert_eq!(consumed_indices, vec![0, 1]);
+        assert_eq!(queue.consume_idx(), 2);
+        assert_eq!(queue.in_flight_count(), 1);
+        assert!(queue.check_owner(0, 2, YCQueueOwner::Consumer));
+        assert!(queue.check_owner(2, 1, YCQueueOwner::Consumer));
+
+        queue.mark_slots_consumed(consume_slots_first).unwrap();
+        assert!(queue.check_owner(0, 2, YCQueueOwner::Producer));
+        assert!(queue.check_owner(2, 1, YCQueueOwner::Consumer));
+        assert_eq!(queue.in_flight_count(), 1);
+
+        let final_slot = queue.get_consume_slots(1).unwrap();
+        assert_eq!(final_slot[0].index, 2);
+        assert_eq!(queue.in_flight_count(), 0);
+        assert_eq!(queue.consume_idx(), 3);
+
+        queue.mark_slots_consumed(final_slot).unwrap();
+        assert!(queue.check_owner(0, slot_count, YCQueueOwner::Producer));
+        assert_eq!(queue.in_flight_count(), 0);
+        assert_eq!(queue.produce_idx(), 3);
+        assert_eq!(queue.consume_idx(), 3);
+    }
+
+    #[test]
+    fn wrap_test() {
+        let slot_count: u16 = 4;
+        let slot_size: u16 = 32;
+
+        let mut owned = YCQueueOwnedData::new(slot_count, slot_size);
+        let shared_meta = YCQueueSharedMeta::new(&owned.meta);
+        let mut queue = YCQueue::new(shared_meta, owned.data.as_mut_slice()).unwrap();
+
+        let initial_slots = queue.get_produce_slots(slot_count).unwrap();
+        assert_eq!(queue.in_flight_count(), slot_count);
+        assert_eq!(queue.produce_idx(), 0);
+
+        queue.mark_slots_produced(initial_slots).unwrap();
+        assert!(queue.check_owner(0, slot_count, YCQueueOwner::Consumer));
+
+        let first_consumed = queue.get_consume_slots(slot_count).unwrap();
+        assert_eq!(queue.in_flight_count(), 0);
+        assert_eq!(queue.consume_idx(), 0);
+
+        queue.mark_slots_consumed(first_consumed).unwrap();
+        assert!(queue.check_owner(0, slot_count, YCQueueOwner::Producer));
+        assert_eq!(queue.in_flight_count(), 0);
+        assert_eq!(queue.produce_idx(), 0);
+        assert_eq!(queue.consume_idx(), 0);
+
+        let mut wrap_slots = queue.get_produce_slots(3).unwrap();
+        let start_idx = wrap_slots[0].index;
+        assert!(start_idx <= slot_count - 3 || start_idx == slot_count - 3);
+
+        wrap_slots[0].data.fill(0xAA);
+        wrap_slots[1].data.fill(0xBB);
+        wrap_slots[2].data.fill(0xCC);
+
+        queue.mark_slots_produced(wrap_slots).unwrap();
+        assert_eq!(queue.in_flight_count(), 3);
+
+        let consumed = queue.get_consume_slots(3).unwrap();
+        let values: Vec<u8> = consumed.iter().map(|slot| slot.data[0]).collect();
+        assert_eq!(values, vec![0xAA, 0xBB, 0xCC]);
+        assert_eq!(queue.consume_idx(), (start_idx + 3) % slot_count);
+
+        queue.mark_slots_consumed(consumed).unwrap();
+        assert!(queue.check_owner(0, slot_count, YCQueueOwner::Producer));
+        assert_eq!(queue.in_flight_count(), 0);
     }
 }

--- a/src/queue_alloc_helpers.rs
+++ b/src/queue_alloc_helpers.rs
@@ -15,9 +15,8 @@ impl YCQueueOwnedMeta {
         let slot_count = AtomicU16::new(slot_count_u16);
         let slot_size = AtomicU16::new(slot_size_u16);
         let produce_meta = AtomicU64::new(0);
-        let mut ownership = Vec::<AtomicU64>::with_capacity(
-            (slot_count_u16 as usize).div_ceil(u64::BITS as usize),
-        );
+        let mut ownership =
+            Vec::<AtomicU64>::with_capacity((slot_count_u16 as usize).div_ceil(u64::BITS as usize));
 
         for _i in 0..ownership.capacity() {
             ownership.push(AtomicU64::new(0));
@@ -56,8 +55,7 @@ impl<'a> YCQueueSharedMeta<'a> {
         let produce_meta = unsafe { &*u64_meta_ptr };
 
         let slot_count_u16 = slot_count.load(std::sync::atomic::Ordering::Acquire);
-        let ownership_count =
-            (slot_count_u16 as usize).div_ceil(u64::BITS as usize);
+        let ownership_count = (slot_count_u16 as usize).div_ceil(u64::BITS as usize);
         let ownership_ptr = unsafe { u64_meta_ptr.add(1) };
 
         let ownership_slice =

--- a/tests/multi_thread_tests.rs
+++ b/tests/multi_thread_tests.rs
@@ -84,6 +84,94 @@ mod tests {
     }
 
     #[test]
+    fn batched_simple_produce_consume_test() {
+        let slot_count: u16 = 64;
+        let slot_size: u16 = 64;
+        let num_iterations: u16 = 10;
+        let batch_size: u16 = 5;
+
+        let owned_data = YCQueueOwnedData::new(slot_count, slot_size);
+
+        let consume_data = YCQueueSharedData::from_owned_data(&owned_data);
+        let produce_data = YCQueueSharedData::from_owned_data(&owned_data);
+
+        let mut consume_queue = YCQueue::new(consume_data.meta, consume_data.data).unwrap();
+        let mut produce_queue = YCQueue::new(produce_data.meta, produce_data.data).unwrap();
+
+        let total_messages = (slot_count as usize) * (num_iterations as usize);
+
+        std::thread::scope(|s| {
+            s.spawn(move || {
+                let mut next_expected = 0usize;
+                while next_expected < total_messages {
+                    let remaining = total_messages - next_expected;
+                    let request = std::cmp::min(batch_size as usize, remaining) as u16;
+
+                    match consume_queue.get_consume_slots(request) {
+                        Ok(slots) => {
+                            for (offset, slot) in slots.iter().enumerate() {
+                                let expected = format!("hello-{}", next_expected + offset);
+                                assert_eq!(str_from_u8(slot.data), expected);
+                            }
+                            consume_queue.mark_slots_consumed(slots).unwrap();
+                            next_expected += request as usize;
+                        }
+                        Err(YCQueueError::EmptyQueue) | Err(YCQueueError::SlotNotReady) => {
+                            match consume_queue.get_consume_slot() {
+                                Ok(slot) => {
+                                    let expected = format!("hello-{}", next_expected);
+                                    assert_eq!(str_from_u8(slot.data), expected);
+                                    consume_queue.mark_slot_consumed(slot).unwrap();
+                                    next_expected += 1;
+                                }
+                                Err(YCQueueError::EmptyQueue) | Err(YCQueueError::SlotNotReady) => {
+                                    std::thread::yield_now();
+                                }
+                                Err(e) => panic!("unexpected error batching consume: {:?}", e),
+                            }
+                        }
+                        Err(e) => panic!("unexpected error consuming batched slots: {:?}", e),
+                    }
+                }
+            });
+
+            s.spawn(move || {
+                let mut next_to_send = 0usize;
+                while next_to_send < total_messages {
+                    let remaining = total_messages - next_to_send;
+                    let request = std::cmp::min(batch_size as usize, remaining) as u16;
+
+                    match produce_queue.get_produce_slots(request) {
+                        Ok(mut slots) => {
+                            for (offset, slot) in slots.iter_mut().enumerate() {
+                                let msg = format!("hello-{}", next_to_send + offset);
+                                copy_str_to_slice(&msg, &mut slot.data);
+                            }
+                            produce_queue.mark_slots_produced(slots).unwrap();
+                            next_to_send += request as usize;
+                        }
+                        Err(YCQueueError::OutOfSpace) | Err(YCQueueError::SlotNotReady) => {
+                            match produce_queue.get_produce_slot() {
+                                Ok(mut slot) => {
+                                    let msg = format!("hello-{}", next_to_send);
+                                    copy_str_to_slice(&msg, &mut slot.data);
+                                    produce_queue.mark_slot_produced(slot).unwrap();
+                                    next_to_send += 1;
+                                }
+                                Err(YCQueueError::OutOfSpace) | Err(YCQueueError::SlotNotReady) => {
+                                    std::thread::yield_now()
+                                }
+                                Err(e) => panic!("unexpected error batching produce: {:?}", e),
+                            }
+                        }
+                        Err(e) => panic!("unexpected error producing batched slots: {:?}", e),
+                    }
+                }
+            });
+        });
+    }
+
+    #[test]
     /**
      * Test with multiple producers and multiple consumers.
      */
@@ -190,7 +278,6 @@ mod tests {
                                 Ok(mut produce_slot) => {
                                     let produce_str = format!("hello-{}", id);
                                     copy_str_to_slice(&produce_str, &mut produce_slot.data);
-                                    print!("{}:{}\n", produce_slot.index, produce_str);
                                     produce_queue.mark_slot_produced(produce_slot).unwrap();
 
                                     assert!(
@@ -243,6 +330,189 @@ mod tests {
                 "missing received id: {}, ids: {:?}",
                 i,
                 received_ids
+            );
+        }
+    }
+
+    #[test]
+    fn batched_multi_produce_consume_test() {
+        let slot_count: u16 = 64;
+        let slot_size: u16 = 64;
+        let num_iterations: u16 = 50;
+        let num_producers: u16 = 4;
+        let num_consumers: u16 = 4;
+        let batch_size: u16 = 5;
+        let timeout = std::time::Duration::from_secs(10);
+
+        let owned_data = YCQueueOwnedData::new(slot_count, slot_size);
+
+        let mut consumer_queues = Vec::with_capacity(num_consumers as usize);
+        for _ in 0..num_consumers {
+            let data = YCQueueSharedData::from_owned_data(&owned_data);
+            consumer_queues.push(YCQueue::new(data.meta, data.data).unwrap());
+        }
+
+        let mut producer_queues = Vec::with_capacity(num_producers as usize);
+        for _ in 0..num_producers {
+            let data = YCQueueSharedData::from_owned_data(&owned_data);
+            producer_queues.push(YCQueue::new(data.meta, data.data).unwrap());
+        }
+
+        let max_messages = (slot_count as u32) * (num_iterations as u32);
+        let produce_counter = Arc::new(AtomicU32::new(0));
+
+        let received_ids = Arc::new(Mutex::new(HashSet::<u32>::new()));
+        let sent_ids = Arc::new(Mutex::new(HashSet::<u32>::new()));
+
+        let deadline = std::time::Instant::now() + timeout;
+
+        std::thread::scope(|s| {
+            for i in 0..num_consumers {
+                let builder = std::thread::Builder::new().name(format!("batched_consumer_{}", i));
+                let received_ids = Arc::clone(&received_ids);
+                let mut consume_queue = consumer_queues.pop().unwrap();
+                builder
+                    .spawn_scoped(s, move || {
+                        loop {
+                            {
+                                if received_ids.lock().unwrap().len() >= max_messages as usize {
+                                    break;
+                                }
+                            }
+
+                            let remaining = {
+                                let guard = received_ids.lock().unwrap();
+                                max_messages as usize - guard.len()
+                            };
+                            let request = std::cmp::min(batch_size as usize, remaining) as u16;
+
+                            if request == 0 {
+                                break;
+                            }
+
+                            match consume_queue.get_consume_slots(request) {
+                                Ok(slots) => {
+                                    for slot in slots.iter() {
+                                        let message = str_from_u8(slot.data);
+                                        let id_str = message
+                                            .strip_prefix("hello-")
+                                            .expect(format!("bad message: {}", message).as_str());
+                                        let id: u32 = id_str
+                                            .parse()
+                                            .expect(format!("bad message: {}", message).as_str());
+                                        assert!(id < max_messages, "id {} out of range", id);
+                                        assert!(
+                                            received_ids.lock().unwrap().insert(id),
+                                            "duplicate message received: {}",
+                                            id
+                                        );
+                                    }
+                                    consume_queue.mark_slots_consumed(slots).unwrap();
+                                }
+                                Err(YCQueueError::EmptyQueue) | Err(YCQueueError::SlotNotReady) => {
+                                    match consume_queue.get_consume_slot() {
+                                        Ok(slot) => {
+                                            let message = str_from_u8(slot.data);
+                                            let id_str = message.strip_prefix("hello-").expect(
+                                                format!("bad message: {}", message).as_str(),
+                                            );
+                                            let id: u32 = id_str.parse().expect(
+                                                format!("bad message: {}", message).as_str(),
+                                            );
+                                            assert!(id < max_messages, "id {} out of range", id);
+                                            assert!(
+                                                received_ids.lock().unwrap().insert(id),
+                                                "duplicate message received: {}",
+                                                id
+                                            );
+                                            consume_queue.mark_slot_consumed(slot).unwrap();
+                                        }
+                                        Err(YCQueueError::EmptyQueue)
+                                        | Err(YCQueueError::SlotNotReady) => {
+                                            std::thread::yield_now()
+                                        }
+                                        Err(e) => panic!("unexpected error consuming: {:?}", e),
+                                    }
+                                }
+                                Err(e) => {
+                                    panic!("unexpected error consuming batched slots: {:?}", e)
+                                }
+                            }
+
+                            if std::time::Instant::now() > deadline {
+                                panic!("batched consumer timed out after {:?}", timeout);
+                            }
+                        }
+                    })
+                    .unwrap();
+            }
+
+            for i in 0..num_producers {
+                let builder = std::thread::Builder::new().name(format!("batched_producer_{}", i));
+                let sent_ids = Arc::clone(&sent_ids);
+                let mut produce_queue = producer_queues.pop().unwrap();
+                let counter = Arc::clone(&produce_counter);
+                builder
+                    .spawn_scoped(s, move || {
+                        loop {
+                            let chunk_start =
+                                counter.fetch_add(batch_size as u32, Ordering::AcqRel);
+                            if chunk_start >= max_messages {
+                                break;
+                            }
+
+                            let remaining = max_messages - chunk_start;
+                            let request = std::cmp::min(batch_size as u32, remaining) as u16;
+
+                            loop {
+                                match produce_queue.get_produce_slots(request) {
+                                    Ok(mut slots) => {
+                                        for (offset, slot) in slots.iter_mut().enumerate() {
+                                            let id = chunk_start + offset as u32;
+                                            let produce_str = format!("hello-{}", id);
+                                            copy_str_to_slice(&produce_str, &mut slot.data);
+                                            assert!(
+                                                sent_ids.lock().unwrap().insert(id),
+                                                "duplicate message sent: {}",
+                                                id
+                                            );
+                                        }
+                                        produce_queue.mark_slots_produced(slots).unwrap();
+                                        break;
+                                    }
+                                    Err(YCQueueError::OutOfSpace)
+                                    | Err(YCQueueError::SlotNotReady) => {
+                                        std::thread::yield_now();
+                                    }
+                                    Err(e) => {
+                                        panic!("unexpected error producing batched slots: {:?}", e);
+                                    }
+                                }
+
+                                if std::time::Instant::now() > deadline {
+                                    panic!("batched producer timed out after {:?}", timeout);
+                                }
+                            }
+                        }
+                    })
+                    .unwrap();
+            }
+        });
+
+        assert!(produce_counter.load(Ordering::Acquire) >= max_messages);
+        assert_eq!(sent_ids.lock().unwrap().len(), max_messages as usize);
+        assert_eq!(received_ids.lock().unwrap().len(), max_messages as usize);
+
+        for id in 0..max_messages {
+            assert!(
+                sent_ids.lock().unwrap().contains(&id),
+                "missing sent id {}",
+                id
+            );
+            assert!(
+                received_ids.lock().unwrap().contains(&id),
+                "missing received id {}",
+                id
             );
         }
     }


### PR DESCRIPTION
Couple changes:
1. delet produce pending, prob won't need it. This simplifies mark_produced to reduce cache line bouncing, as well as reducing overall complexity. 
2. Add batched reserve and mark for produce and consume APIs. 