### PR TITLE
Add try API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "yep_coc"
+name = "yep-coc"
 version = "0.1.0"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
-yep coc
+# yep-coc
 
-Design located in design.md. 
+[![Crates.io](https://img.shields.io/crates/v/yep-coc.svg)](https://crates.io/crates/yep-coc) [![Documentation](https://docs.rs/yep-coc/badge.svg)](https://docs.rs/yep-coc) [![Rust](https://github.com/richkcho/yep-coc/actions/workflows/rust.yml/badge.svg)](https://github.com/richkcho/yep-coc/actions/workflows/rust.yml)
+
+## Overview
+- Multi-producer, multi-consumer lock-free queue built for zero-copy data paths.
+- Reserve/submit workflow lets producers publish buffers without blocking each other, while consumers reclaim slots independently.
+- Designed for high-performance IPC scenarios
+
+## Design Highlights
+- Queue metadata is stored separately from the contiguous data region so corruption in payload does not affect queue state.
+- Ownership of each slot is tracked with atomics, enabling concurrent producers and consumers without coarse locking.
+- Producers and consumers operate on `YCQueueProduceSlot` and `YCQueueConsumeSlot` handles, making it explicit when data is ready.
+- The API supports batching for reserve/submit/consume operations; single-slot helpers are layered on top for convenience.
+
+## Quick Start
+```rust
+use yep_coc::queue_alloc_helpers::YCQueueOwnedData;
+use yep_coc::{YCQueue, YCQueueSharedMeta};
+
+fn main() {
+    // Allocate backing storage for 4 slots of 128 bytes each.
+    let mut owned = YCQueueOwnedData::new(4, 128);
+    let shared = YCQueueSharedMeta::new(&owned.meta);
+    let mut queue = YCQueue::new(shared, owned.data.as_mut_slice()).expect("queue");
+
+    // Producer: reserve a slot, write data, then publish it.
+    let mut produce_slot = queue.get_produce_slot().expect("produce slot");
+    produce_slot.data[..5].copy_from_slice(b"hello");
+    queue.mark_slot_produced(produce_slot).expect("publish");
+
+    // Consumer: take the slot, read the data, and return it to producers.
+    let consume_slot = queue.get_consume_slot().expect("consume slot");
+    assert_eq!(&consume_slot.data[..5], b"hello");
+    queue.mark_slot_consumed(consume_slot).expect("reclaim");
+}
+```
+
+For more complete examples, check `examples/simple-send-recv.rs` and `examples/multi-send-recv.rs`.

--- a/design.md
+++ b/design.md
@@ -6,7 +6,7 @@ My expected users of this queue are users who want to implement high performance
 1. Provide zero-copy API for producers and consumers of the queue. Zero copy in the context of using the queue does not incur an additional copy.
 2. Producers shouldn't block each other when accessing queue data, neither should consumers. Multiple producers should be able to "reserve" a slot, copy / DMA into it, then publish the data. Consumers should also be able to do the same. 
 3. Metadata region should live in a separate memory region than the queue data. The data section should be "corruptible" without breaking queue state - only transferred data should be corrupted. 
-4. No unreasonable assumptions about memory allocator or scheduler that would prevent this library from living in driver code or FW code. 
+4. No unreasonable assumptions about memory allocator or scheduler that would prevent this library from living in driver code or FW code. Currently, the state of the code *does* depend on `std`, but only on `Cell` and atomics, which I feel is reasonable. 
 
 ## Later Goals
 1. Perf benchmark, worry about whether I should store queue info in one atomic vs two. (cache line separation could increase perf if there's high contention)

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -3,3 +3,6 @@ name = "test_support"
 version = "0.0.1"
 edition = "2024"
 publish = false
+
+[dependencies]
+yep-cache-line-size = "0.9"


### PR DESCRIPTION
* Added best-effort queue APIs (try_get_produce_slots, try_get_consume_slots) plus underlying owner-counting logic and thorough doc comments.
* Expanded README/design notes and doctests with MPMC overview and quick-start example.
* Augmented unit tests and support utilities to cover the new try-path behavior and keep helpers aligned.